### PR TITLE
Fix errors in Vagrantfile

### DIFF
--- a/examples/libvirt/Vagrantfile
+++ b/examples/libvirt/Vagrantfile
@@ -35,14 +35,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         node.vm.network :private_network, ip: "#{net}.#{ipaddr}"
       end
 
-      puppet.vm.hostname = name
+      node.vm.hostname = name
 
-    puppet.vm.synced_folder "../../", "/openstack"
+      node.vm.synced_folder "../../", "/openstack"
 
-    puppet.vm.provider "libvirt" do |v|
-      v.memory = 2048
-      v.nested = true  # Do we actually want this?
+      node.vm.provider "libvirt" do |v|
+        v.memory = 2048
+        v.nested = true  # Do we actually want this?
+      end
     end
   end
-
 end


### PR DESCRIPTION
There was a syntax error (missing `end`), and some of the statements
should have been using node instead of puppet.
