### PR TITLE
Specify libvirt as the provider for hostmanager.

### DIFF
--- a/examples/libvirt/05_up.sh
+++ b/examples/libvirt/05_up.sh
@@ -2,4 +2,4 @@
 # This is the script for bringing up the standard openstack nodes without
 # Swift. This is probably the up script you want to run.
 vagrant up --provider libvirt puppet control storage network compute
-vagrant hostmanager
+vagrant hostmanager --provider libvirt


### PR DESCRIPTION
Forgot to make a separate branch for this fix earlier, but the rest of this branch is already merged in, so oh well.
