### PR TITLE
Freeze most puppet modules at latest release.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -4,7 +4,7 @@ forge "http://forge.puppetlabs.com"
 
 mod "keystone",
   :git => "git://github.com/stackforge/puppet-keystone",
-  :ref => "master"
+  :ref => "4.1.0"
 
 mod "swift",
   :git => "git://github.com/stackforge/puppet-swift",
@@ -12,27 +12,27 @@ mod "swift",
 
 mod "glance",
   :git => "git://github.com/stackforge/puppet-glance",
-  :ref => "master"
+  :ref => "4.1.0"
 
 mod "cinder",
   :git => "git://github.com/stackforge/puppet-cinder",
-  :ref => "master"
+  :ref => "4.1.0"
 
 mod "neutron",
   :git => "git://github.com/stackforge/puppet-neutron",
-  :ref => "master"
+  :ref => "4.2.0"
 
 mod "nova",
   :git => "git://github.com/stackforge/puppet-nova",
-  :ref => "master"
+  :ref => "4.1.0"
 
 mod "heat",
   :git => "git://github.com/stackforge/puppet-heat",
-  :ref => "master"
+  :ref => "4.1.0"
 
 mod "ceilometer",
   :git => "git://github.com/stackforge/puppet-ceilometer",
-  :ref => "master"
+  :ref => "4.1.0"
 
 mod "horizon",
   :git => "git://github.com/stackforge/puppet-horizon",
@@ -52,7 +52,7 @@ mod "vswitch",
 
 mod "apache",
   :git => "git://github.com/puppetlabs/puppetlabs-apache",
-  :ref => "master"
+  :ref => "1.1.1"
 
 mod "inifile",
   :git => "git://github.com/puppetlabs/puppetlabs-inifile",


### PR DESCRIPTION
Most of the Openstack-related puppet modules were causing errors to do
with mysql when building our environment -- we're now using the released
versions, which are known to work.

There are a few services, like tempest, whose manifests didn't include
the offending code; those have been left alone for now.
